### PR TITLE
sommelier => 20220411

### DIFF
--- a/sommelier-wrapper
+++ b/sommelier-wrapper
@@ -1,4 +1,5 @@
-#!/usr/bin/env -S bash -eu
+#!/usr/bin/env bash
+set -eu
 
 BINDIR="$(dirname "$(command -v "${0}")")"
 ARCH="$(uname -m)"

--- a/sommelierd
+++ b/sommelierd
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S ruby --disable-all
+#!/usr/bin/env bash
+eval "exec ruby --disable-all -x '${0}' ${@}"
+#!ruby
 require 'fileutils'
 require 'securerandom'
 

--- a/sommelierd
+++ b/sommelierd
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
-eval "exec ruby --disable-all -x '${0}' ${@}"
-#!ruby
+#!/usr/bin/env ruby
 require 'fileutils'
 require 'securerandom'
 


### PR DESCRIPTION
Fix skycocker/chromebrew#6961

### Changes
- Update sommelier to 20220411 (commit 6e2cc8)
- Remove `-S` argument from `env`

Tested on `x86_64`, X and Wayland work with acceleration.